### PR TITLE
Added a file for Candidate Synthesis for resource Type AWS::EC2::SecurityGroup

### DIFF
--- a/relationships/candidates/AWSEC2SecurityGroup.yml
+++ b/relationships/candidates/AWSEC2SecurityGroup.yml
@@ -1,0 +1,16 @@
+category: AWSEC2SecurityGroup
+lookups:
+- entityTypes:
+  - domain: INFRA
+    type: AWSEC2SecurityGroup
+  tags:
+    matchingMode: ALL
+    predicates:
+      - tagKeys: ["sg-080fce45279e33f77"]
+        field: sg-080fce45279e33f77
+    onMatch:
+      onMultipleMatches: RELATE_ALL
+    onMiss:
+      action: CREATE_UNINSTRUMENTED
+      uninstrumented:
+        type: AWSEC2SecurityGroup


### PR DESCRIPTION
category: AWSEC2SecurityGroup
lookups:
- entityTypes:
  - domain: INFRA
    type: AWSEC2SecurityGroup
  tags:
    matchingMode: ALL
    predicates:
      - tagKeys: ["sg-080fce45279e33f77"]
        field: sg-080fce45279e33f77
    onMatch:
      onMultipleMatches: RELATE_ALL
    onMiss:
      action: CREATE_UNINSTRUMENTED
      uninstrumented:
        type: AWSEC2SecurityGroup